### PR TITLE
Add agent discovery example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # a2a-examples
+
+This repository contains a minimal example showing how simple Python agents can
+be discovered automatically and orchestrated from a main process.
+
+## Running
+
+After installing Python 3.12, run the `main.py` script:
+
+```bash
+python3 main.py
+```
+
+The orchestrator will discover agents defined in the `agents/` package and run
+them sequentially.
+

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import importlib
+import pkgutil
+from dataclasses import dataclass
+from typing import Iterable, List, Protocol
+
+
+class Agent(Protocol):
+    name: str
+
+    def run(self, message: str) -> str:
+        ...
+
+
+def discover_agents() -> List[Agent]:
+    agents: List[Agent] = []
+    package = __name__
+    for _, mod_name, _ in pkgutil.iter_modules([__path__[0]]):
+        if mod_name == '__init__':
+            continue
+        module = importlib.import_module(f'{package}.{mod_name}')
+        agent_obj = getattr(module, 'agent', None)
+        if agent_obj is not None:
+            agents.append(agent_obj)
+    return agents

--- a/agents/echo_agent.py
+++ b/agents/echo_agent.py
@@ -1,0 +1,9 @@
+from . import Agent
+
+class EchoAgent:
+    name = "echo"
+
+    def run(self, message: str) -> str:
+        return f"Echo: {message}"
+
+agent: Agent = EchoAgent()

--- a/agents/reverse_agent.py
+++ b/agents/reverse_agent.py
@@ -1,0 +1,9 @@
+from . import Agent
+
+class ReverseAgent:
+    name = "reverse"
+
+    def run(self, message: str) -> str:
+        return message[::-1]
+
+agent: Agent = ReverseAgent()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+from agents import discover_agents
+
+
+def main():
+    agents = discover_agents()
+    print(f"Discovered {len(agents)} agents: {[a.name for a in agents]}")
+
+    input_message = "Hello, Agents!"
+    print(f"Input: {input_message}")
+    for agent in agents:
+        response = agent.run(input_message)
+        print(f"{agent.name} -> {response}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a minimal agent discovery mechanism
- add example echo and reverse agents
- orchestrate agents in `main.py`
- document running the example in README

## Testing
- `python3 main.py`

------
https://chatgpt.com/codex/tasks/task_e_686c45673c9c8331a6b6b1ddd8a942b9