### PR TITLE
Add A2A orchestration example

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,57 @@
+import logging
+
+import click
+import httpx
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryPushNotifier, InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+
+from agent_executor import EchoReverseAgentExecutor
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("--host", default="localhost")
+@click.option("--port", default=10020)
+def main(host: str, port: int) -> None:
+    """Starts the A2A server orchestrating local agents."""
+    httpx_client = httpx.AsyncClient()
+    request_handler = DefaultRequestHandler(
+        agent_executor=EchoReverseAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        push_notifier=InMemoryPushNotifier(httpx_client),
+    )
+
+    server = A2AStarletteApplication(
+        agent_card=get_agent_card(host, port), http_handler=request_handler
+    )
+
+    import uvicorn
+
+    uvicorn.run(server.build(), host=host, port=port)
+
+
+def get_agent_card(host: str, port: int) -> AgentCard:
+    capabilities = AgentCapabilities(streaming=False)
+    skill = AgentSkill(
+        id="echo_reverse",
+        name="Echo Reverse",
+        description="Echo the message then reverse it",
+    )
+    return AgentCard(
+        name="EchoReverseServer",
+        description="Runs Echo and Reverse agents sequentially",
+        url=f"http://{host}:{port}/",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=capabilities,
+        skills=[skill],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_executor.py
+++ b/agent_executor.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from a2a.server.agent_execution.agent_executor import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.types import (
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from a2a.utils import new_task, new_text_artifact
+
+from agents import discover_agents
+
+logger = logging.getLogger(__name__)
+
+
+class EchoReverseAgentExecutor(AgentExecutor):
+    """Simple AgentExecutor that runs all discovered agents sequentially."""
+
+    def __init__(self) -> None:
+        self.agents = discover_agents()
+        logger.info("Discovered agents: %s", [a.name for a in self.agents])
+
+    async def execute(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        query = context.get_user_input()
+        task = context.current_task
+        if not task:
+            task = new_task(context.message)
+            await event_queue.enqueue_event(task)
+
+        result = query
+        for agent in self.agents:
+            logger.debug("Running agent %s", agent.name)
+            result = agent.run(result)
+
+        await event_queue.enqueue_event(
+            TaskArtifactUpdateEvent(
+                append=False,
+                contextId=task.contextId,
+                taskId=task.id,
+                lastChunk=True,
+                artifact=new_text_artifact(
+                    name="result",
+                    description="Result of composed agents",
+                    text=result,
+                ),
+            )
+        )
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                status=TaskStatus(state=TaskState.completed),
+                final=True,
+                contextId=task.contextId,
+                taskId=task.id,
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise Exception("cancel not supported")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "a2a_examples"
+version = "0.1.0"
+dependencies = [
+    "a2a-sdk",
+    "httpx",
+    "uvicorn",
+    "click",
+]
+
+[tool.pytest.ini_options]
+addopts = "-vv"
+

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,7 @@
+from agents import discover_agents
+
+
+def test_discover_agents():
+    agents = discover_agents()
+    names = sorted([a.name for a in agents])
+    assert names == ["echo", "reverse"]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.types import Message, MessageSendParams, Part, Role, TextPart, TaskArtifactUpdateEvent, TaskStatusUpdateEvent, TaskState
+
+from agent_executor import EchoReverseAgentExecutor
+
+
+@pytest.mark.asyncio
+async def test_executor_runs_agents_sequentially():
+    executor = EchoReverseAgentExecutor()
+    message = Message(
+        role=Role.user,
+        messageId="1",
+        parts=[Part(root=TextPart(text="hello"))],
+    )
+    params = MessageSendParams(message=message)
+    context = RequestContext(params)
+    queue = EventQueue()
+
+    await executor.execute(context, queue)
+
+    events = []
+    while not queue.queue.empty():
+        events.append(await queue.dequeue_event())
+
+    artifact_event = next(e for e in events if isinstance(e, TaskArtifactUpdateEvent))
+    status_event = next(e for e in events if isinstance(e, TaskStatusUpdateEvent))
+
+    assert artifact_event.artifact.parts[0].root.text == "olleh :ohcE"
+    assert status_event.status.state == TaskState.completed


### PR DESCRIPTION
## Summary
- add pyproject with a2a-sdk dependency
- implement an A2A agent executor that coordinates local agents
- add a CLI entrypoint that starts an A2A server
- test agent discovery and executor behavior

## Testing
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c55b63db08331abc90898b3621b92