### PR TITLE
Add CI workflow and contributor guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+exclude = .git,__pycache__,build,dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 build pytest pytest-asyncio
+          pip install -e .
+      - name: Lint
+        run: flake8 .
+      - name: Build
+        run: python -m build
+      - name: Test
+        run: pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Codex Contribution Guidelines
+
+This repository uses GitHub Actions as a continuous integration (CI) gate. Before
+sending a pull request, Codex must run the same checks locally:
+
+1. **Lint** using `flake8`.
+2. **Build** the project using `python -m build`.
+3. **Test** using `pytest`.
+
+Always run these commands and ensure they succeed before committing.
+
+Additional best practices:
+
+- Clean up any temporary files you open or generate.
+- Remove unused or abandoned code rather than commenting it out.
+- Always `git pull --rebase` the latest changes from both your feature branch
+  and `main` before starting work.
+- Resolve all merge conflicts locally prior to creating a PR.
+- Keep pull requests focused and provide clear commit messages.
+- Follow the formatting defined in `.editorconfig` and `.flake8`.
+- Keep the repository free of secrets and personal data.
+
+CI scripts live in `.github/workflows/ci.yml` and must remain up to date with
+any required steps. Codex should run these checks exactly as defined.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ python3 main.py
 The orchestrator will discover agents defined in the `agents/` package and run
 them sequentially.
 
+
+## Development
+
+Install development dependencies and run the checks used in CI:
+
+```bash
+pip install flake8 build pytest pytest-asyncio
+pip install -e .
+flake8 .
+python -m build
+pytest
+```

--- a/agent_executor.py
+++ b/agent_executor.py
@@ -61,6 +61,7 @@ class EchoReverseAgentExecutor(AgentExecutor):
             )
         )
 
-    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+    async def cancel(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
         raise Exception("cancel not supported")
-

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 import importlib
 import pkgutil
-from dataclasses import dataclass
-from typing import Iterable, List, Protocol
+from typing import List, Protocol
 
 
 class Agent(Protocol):

--- a/agents/echo_agent.py
+++ b/agents/echo_agent.py
@@ -1,9 +1,11 @@
 from . import Agent
 
+
 class EchoAgent:
     name = "echo"
 
     def run(self, message: str) -> str:
         return f"Echo: {message}"
+
 
 agent: Agent = EchoAgent()

--- a/agents/reverse_agent.py
+++ b/agents/reverse_agent.py
@@ -1,9 +1,11 @@
 from . import Agent
 
+
 class ReverseAgent:
     name = "reverse"
 
     def run(self, message: str) -> str:
         return message[::-1]
+
 
 agent: Agent = ReverseAgent()

--- a/main.py
+++ b/main.py
@@ -11,5 +11,6 @@ def main():
         response = agent.run(input_message)
         print(f"{agent.name} -> {response}")
 
+
 if __name__ == "__main__":
     main()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,11 +1,22 @@
-import asyncio
-
 import pytest
 from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events.event_queue import EventQueue
-from a2a.types import Message, MessageSendParams, Part, Role, TextPart, TaskArtifactUpdateEvent, TaskStatusUpdateEvent, TaskState
+from a2a.types import (
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    TextPart,
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+    TaskState,
+)
 
-from agent_executor import EchoReverseAgentExecutor
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from agent_executor import EchoReverseAgentExecutor  # noqa: E402
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint/build/test on every push and PR
- define flake8 rules and editor configuration
- document local development workflow
- provide contribution guidelines for Codex
- fix lint errors

## Testing
- `flake8 .`
- `python -m build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c68ed41e4833192975973ac671544